### PR TITLE
Add contract ingestion classes

### DIFF
--- a/app/ingestion/ingestor.py
+++ b/app/ingestion/ingestor.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import fitz  # PyMuPDF
+from docx import Document as DocxDocument
+
+from app.storage.vector_store_adapter import VectorStoreAdapter
+from app.storage.relational_db_adapter import RelationalDBAdapter
+
+
+class ContractIngestor:
+    """Ingests PDF and DOCX contracts from a directory."""
+
+    def __init__(
+        self,
+        directory: str | Path,
+        vector_store: VectorStoreAdapter,
+        relational_db: RelationalDBAdapter,
+    ) -> None:
+        self.directory = Path(directory)
+        self.vector_store = vector_store
+        self.relational_db = relational_db
+
+    def ingest(self) -> None:
+        for file_path in self.directory.iterdir():
+            if not file_path.is_file():
+                continue
+            ext = file_path.suffix.lower()
+            if ext == ".pdf":
+                text = self._extract_pdf(file_path)
+            elif ext == ".docx":
+                text = self._extract_docx(file_path)
+            else:
+                continue
+
+            metadata = {"source": str(file_path)}
+            self.vector_store.add_document(text, metadata)
+            self.relational_db.add_contract(
+                name=file_path.name,
+                path=str(file_path),
+                ingestion_date=datetime.utcnow(),
+            )
+        self.vector_store.persist()
+
+    def _extract_pdf(self, path: Path) -> str:
+        doc = fitz.open(path)
+        text = "".join(page.get_text() for page in doc)
+        doc.close()
+        return text
+
+    def _extract_docx(self, path: Path) -> str:
+        doc = DocxDocument(path)
+        text = "\n".join(paragraph.text for paragraph in doc.paragraphs)
+        return text

--- a/app/storage/relational_db_adapter.py
+++ b/app/storage/relational_db_adapter.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from sqlalchemy import create_engine, Column, Integer, String, DateTime
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+Base = declarative_base()
+
+
+class Contract(Base):
+    __tablename__ = "contracts"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    path = Column(String, nullable=False)
+    ingestion_date = Column(DateTime, default=datetime.utcnow)
+
+
+class RelationalDBAdapter:
+    """Simple SQLite wrapper for storing contract metadata."""
+
+    def __init__(self, db_url: str = "sqlite:///data/contracts.db") -> None:
+        self._engine = create_engine(db_url, connect_args={"check_same_thread": False})
+        Base.metadata.create_all(self._engine)
+        self._Session = sessionmaker(bind=self._engine)
+
+    def add_contract(
+        self, name: str, path: str, ingestion_date: datetime | None = None
+    ) -> None:
+        session = self._Session()
+        contract = Contract(
+            name=name, path=path, ingestion_date=ingestion_date or datetime.utcnow()
+        )
+        session.add(contract)
+        session.commit()
+        session.close()

--- a/app/storage/vector_store_adapter.py
+++ b/app/storage/vector_store_adapter.py
@@ -1,0 +1,21 @@
+from langchain.embeddings import OpenAIEmbeddings
+from langchain.vectorstores import Chroma
+
+
+class VectorStoreAdapter:
+    """Wrapper around Chroma vector store using OpenAI embeddings."""
+
+    def __init__(self, persist_directory: str = "chroma_db") -> None:
+        self._persist_directory = persist_directory
+        self._embedding = OpenAIEmbeddings()
+        self._store = Chroma(
+            persist_directory=persist_directory, embedding_function=self._embedding
+        )
+
+    def add_document(self, text: str, metadata: dict | None = None) -> None:
+        """Add a single text document with optional metadata to the store."""
+        self._store.add_texts([text], metadatas=[metadata or {}])
+
+    def persist(self) -> None:
+        """Persist the underlying Chroma store to disk."""
+        self._store.persist()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ openai = "*"
 streamlit = "*"
 SQLAlchemy = "*"
 python-dotenv = "*"
+PyMuPDF = "*"
+python-docx = "*"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"


### PR DESCRIPTION
## Summary
- implement `ContractIngestor` for reading PDF/DOCX files and storing
- add `VectorStoreAdapter` wrapping Chroma and `RelationalDBAdapter` for SQLite
- include PyMuPDF and python-docx in dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ea71ff18832c898236f139048d06