### PR TITLE
Atualiza tabela contracts com novos campos

### DIFF
--- a/app/storage/relational_db_adapter.py
+++ b/app/storage/relational_db_adapter.py
@@ -1,5 +1,14 @@
 from datetime import datetime
-from sqlalchemy import create_engine, Column, Integer, String, DateTime
+from sqlalchemy import (
+    create_engine,
+    Column,
+    Integer,
+    String,
+    DateTime,
+    Date,
+    Float,
+    Numeric,
+)
 from sqlalchemy.orm import declarative_base, sessionmaker
 
 Base = declarative_base()
@@ -13,6 +22,26 @@ class Contract(Base):
     path = Column(String, nullable=False)
     ingestion_date = Column(DateTime, default=datetime.utcnow)
     last_processed = Column(DateTime, default=datetime.utcnow)
+
+    # Additional optional metadata fields
+    contrato = Column(String, nullable=True)
+    inicioPrazo = Column(Date, nullable=True)
+    fimPrazo = Column(Date, nullable=True)
+    empresa = Column(String, nullable=True)
+    icj = Column(String, nullable=True)
+    valorContratoOriginal = Column(Numeric, nullable=True)
+    moeda = Column(String, nullable=True)
+    taxaCambio = Column(Float, nullable=True)
+    gerenteContrato = Column(String, nullable=True)
+    areaContrato = Column(String, nullable=True)
+    modalidade = Column(String, nullable=True)
+    textoModalidade = Column(String, nullable=True)
+    reajuste = Column(String, nullable=True)
+    fornecedor = Column(String, nullable=True)
+    nomeFornecedor = Column(String, nullable=True)
+    tipoContrato = Column(String, nullable=True)
+    objetoContrato = Column(String, nullable=True)
+    linhasServico = Column(String, nullable=True)
 
 
 class RelationalDBAdapter:

--- a/tests/test_relational_db.py
+++ b/tests/test_relational_db.py
@@ -23,6 +23,25 @@ def test_contract_model_attributes():
     assert c.ingestion_date == dt
     assert c.last_processed == dt
     assert Contract.__tablename__ == "contracts"
+    # new optional fields should default to None
+    assert c.contrato is None
+    assert c.inicioPrazo is None
+    assert c.fimPrazo is None
+    assert c.empresa is None
+    assert c.icj is None
+    assert c.valorContratoOriginal is None
+    assert c.moeda is None
+    assert c.taxaCambio is None
+    assert c.gerenteContrato is None
+    assert c.areaContrato is None
+    assert c.modalidade is None
+    assert c.textoModalidade is None
+    assert c.reajuste is None
+    assert c.fornecedor is None
+    assert c.nomeFornecedor is None
+    assert c.tipoContrato is None
+    assert c.objetoContrato is None
+    assert c.linhasServico is None
 
 
 def test_add_contract_inserts_into_db():
@@ -37,6 +56,24 @@ def test_add_contract_inserts_into_db():
     assert row.path == "/tmp/c1.pdf"
     assert isinstance(row.ingestion_date, datetime)
     assert isinstance(row.last_processed, datetime)
+    assert row.contrato is None
+    assert row.inicioPrazo is None
+    assert row.fimPrazo is None
+    assert row.empresa is None
+    assert row.icj is None
+    assert row.valorContratoOriginal is None
+    assert row.moeda is None
+    assert row.taxaCambio is None
+    assert row.gerenteContrato is None
+    assert row.areaContrato is None
+    assert row.modalidade is None
+    assert row.textoModalidade is None
+    assert row.reajuste is None
+    assert row.fornecedor is None
+    assert row.nomeFornecedor is None
+    assert row.tipoContrato is None
+    assert row.objetoContrato is None
+    assert row.linhasServico is None
 
 
 def test_update_processing_date():


### PR DESCRIPTION
## Resumo
- adiciona diversos campos opcionais na tabela `contracts`
- atualiza testes de banco relacional para checar os novos campos

## Testes
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d8c428e68832c83347ac22a65399a