### PR TITLE
Implement EmployeeResolver

### DIFF
--- a/app/processing/employees.py
+++ b/app/processing/employees.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+try:
+    from buscaempregados import busca_empregado
+except ImportError:  # pragma: no cover - library may not be available
+    busca_empregado = None
+
+
+class EmployeeResolver:
+    """Resolve employee information either via real service or internal mock."""
+
+    _MOCK_DATA: dict[str, dict[str, str]] = {
+        "CSLA": {
+            "nome": "CARLOS SANTANA LIMA ALMEIDA",
+            "email": "carlos.almeida@petrobras.com.br",
+            "lotacao": "TI/DEVOPS",
+            "cargo": "ANALISTA DE SISTEMAS PLENO",
+        },
+        "EVIJ": {
+            "nome": "EDUARDO VIEIRA JUNQUEIRA",
+            "email": "eduardo.junqueira@petrobras.com.br",
+            "lotacao": "AUDITORIA/ADG/ACI",
+            "cargo": "AUDITOR SÊNIOR",
+        },
+        "AB9V": {
+            "nome": "ANA BEATRIZ VASCONCELOS",
+            "email": "ana.vasconcelos@petrobras.com.br",
+            "lotacao": "GEOLOGIA/EXPLORAÇÃO",
+            "cargo": "ENGENHEIRA DE PETRÓLEO JUNIOR",
+        },
+        "YUD1": {
+            "nome": "YURI DUARTE DOMINGUES",
+            "email": "yuri.domingues@petrobras.com.br",
+            "lotacao": "SUPRIMENTO/LOGÍSTICA",
+            "cargo": "ESPECIALISTA EM LOGÍSTICA",
+        },
+    }
+
+    def resolve(self, chave: str) -> dict[str, str]:
+        """Return employee data for the given key."""
+        data: dict[str, str] | None = None
+        if busca_empregado is not None:
+            try:
+                data = busca_empregado(chave=chave)
+            except Exception:
+                data = None
+        if not data:
+            data = self._MOCK_DATA.get(chave)
+        if not data:
+            data = {
+                "nome": "DESCONHECIDO",
+                "email": "DESCONHECIDO",
+                "lotacao": "DESCONHECIDO",
+                "cargo": "DESCONHECIDO",
+            }
+        # Always include the queried key
+        data = {**data, "chave": chave}
+        return data
+

--- a/tests/test_employee_resolver.py
+++ b/tests/test_employee_resolver.py
@@ -1,0 +1,51 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+# Ensure repository root is on sys.path
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def reload_module():
+    """Reload employees module to apply current sys.modules state."""
+    if "app.processing.employees" in sys.modules:
+        del sys.modules["app.processing.employees"]
+    return importlib.import_module("app.processing.employees")
+
+
+def test_resolve_with_mock():
+    sys.modules.pop("buscaempregados", None)
+    employees = reload_module()
+    resolver = employees.EmployeeResolver()
+    data = resolver.resolve("CSLA")
+    assert data["nome"] == "CARLOS SANTANA LIMA ALMEIDA"
+    assert data["email"] == "carlos.almeida@petrobras.com.br"
+    unknown = resolver.resolve("XXXX")
+    assert unknown["nome"] == "DESCONHECIDO"
+    assert unknown["chave"] == "XXXX"
+
+
+def test_resolve_with_external_module(monkeypatch):
+    module = types.ModuleType("buscaempregados")
+
+    def fake_busca_empregado(chave):
+        return {"nome": f"NOME {chave}", "email": "x@y", "lotacao": "L", "cargo": "C"}
+
+    module.busca_empregado = fake_busca_empregado
+    sys.modules["buscaempregados"] = module
+
+    employees = reload_module()
+    resolver = employees.EmployeeResolver()
+    data = resolver.resolve("ABCD")
+    assert data == {
+        "chave": "ABCD",
+        "nome": "NOME ABCD",
+        "email": "x@y",
+        "lotacao": "L",
+        "cargo": "C",
+    }
+
+    sys.modules.pop("buscaempregados", None)


### PR DESCRIPTION
## Summary
- add `EmployeeResolver` for employee lookups with optional real service integration
- include unit tests for fallback to mock data and external module usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eaea70394832cbdb098c032dc9324