### PR TITLE
Add manager fields and progress tracking

### DIFF
--- a/app/storage/relational_db_adapter.py
+++ b/app/storage/relational_db_adapter.py
@@ -33,6 +33,8 @@ class Contract(Base):
     moeda = Column(String, nullable=True)
     taxaCambio = Column(Float, nullable=True)
     gerenteContrato = Column(String, nullable=True)
+    nomeGerenteContrato = Column(String, nullable=True)
+    lotacaoGerenteContrato = Column(String, nullable=True)
     areaContrato = Column(String, nullable=True)
     modalidade = Column(String, nullable=True)
     textoModalidade = Column(String, nullable=True)

--- a/tests/test_relational_db.py
+++ b/tests/test_relational_db.py
@@ -33,6 +33,8 @@ def test_contract_model_attributes():
     assert c.moeda is None
     assert c.taxaCambio is None
     assert c.gerenteContrato is None
+    assert c.nomeGerenteContrato is None
+    assert c.lotacaoGerenteContrato is None
     assert c.areaContrato is None
     assert c.modalidade is None
     assert c.textoModalidade is None
@@ -65,6 +67,8 @@ def test_add_contract_inserts_into_db():
     assert row.moeda is None
     assert row.taxaCambio is None
     assert row.gerenteContrato is None
+    assert row.nomeGerenteContrato is None
+    assert row.lotacaoGerenteContrato is None
     assert row.areaContrato is None
     assert row.modalidade is None
     assert row.textoModalidade is None

--- a/tests/test_structured_ingestor.py
+++ b/tests/test_structured_ingestor.py
@@ -39,6 +39,10 @@ def test_ingest_structured_creates_records():
     assert len(rows) == 6
     c = {r.contrato: json.loads(r.linhasServico) for r in rows}
     assert len(c["4600637168"]) == 5
+    first = next(r for r in rows if r.contrato == "4600308523")
+    assert first.nomeGerenteContrato == "CARLOS SANTANA LIMA ALMEIDA"
+    assert first.lotacaoGerenteContrato == "TI/DEVOPS"
+    assert ing.progress == 100.0
 
 
 def test_ingest_structured_skips_existing():
@@ -65,3 +69,11 @@ def test_ingest_structured_full_load_clears():
     rows = _get_all(session)
     session.close()
     assert len(rows) == 6
+
+
+def test_ingest_progress_tracking():
+    db = RelationalDBAdapter(db_url="sqlite:///:memory:")
+    ing = ContractStructuredDataIngestor(DATA_FILE, db)
+    assert ing.progress == 0.0
+    ing.ingest()
+    assert ing.progress == 100.0


### PR DESCRIPTION
## Summary
- support extra manager columns in the contract table
- resolve employee information while ingesting structured data
- track ingestion progress
- test coverage for the new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ec75012c0832c867b9237bc573bd1