### PR TITLE
Use API from Streamlit UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,12 @@ poetry install
 
 # Criar .env com chave da OpenAI (exemplo no .env.example)
 
-# Rodar o app
-poetry run python main.py
-
 # Executar a API FastAPI
 poetry run python api_main.py
+
+# Rodar a interface Streamlit (a API deve estar rodando separadamente)
+# Caso a API esteja em outro host/porta, defina a variável de ambiente
+# `API_BASE_URL` apontando para o novo endereço.
+poetry run python main.py
 
 Este projeto está em desenvolvimento contínuo. As tecnologias utilizadas estão organizadas de forma modular para permitir futura substituição de bancos e serviços (ex: ChromaDB por OpenSearch, SQLite por Cloud SQL, etc).

--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -1,1 +1,5 @@
-# Pacote reservado para configurações da aplicação
+"""Application configuration package."""
+
+from .settings import API_BASE_URL
+
+__all__ = ["API_BASE_URL"]

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1,0 +1,6 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+API_BASE_URL = os.getenv("API_BASE_URL", "http://localhost:8000")


### PR DESCRIPTION
## Summary
- create simple settings module for configuration
- update chat UI to call API instead of local classes
- document that the API must run separately and API_BASE_URL env var controls address

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fd17d3a1c832ca007019ff17f6172