### PR TITLE
Implement task execution logging and tests

### DIFF
--- a/app/storage/execution_tracker.py
+++ b/app/storage/execution_tracker.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from .relational_db_adapter import RelationalDBAdapter
+
+
+class ExecutionTracker:
+    """Facilita registro de execuções de tarefas."""
+
+    def __init__(self, db: RelationalDBAdapter, task_name: str, class_name: str) -> None:
+        self._db = db
+        self.task_name = task_name
+        self.class_name = class_name
+        self.execution_id: int | None = None
+
+    def start(self) -> int:
+        """Cria o registro inicial e retorna o id gerado."""
+        self.execution_id = self._db.create_execution(self.task_name, self.class_name)
+        return self.execution_id
+
+    def update(self, progress: float | None = None, status: str | None = None, message: str | None = None) -> None:
+        """Atualiza informações da execução."""
+        if self.execution_id is None:
+            return
+        self._db.update_execution(self.execution_id, progress=progress, status=status, message=message)
+
+    def finish(self, status: str = "success") -> None:
+        """Marca finalização da execução."""
+        if self.execution_id is None:
+            return
+        self._db.update_execution(
+            self.execution_id,
+            status=status,
+            end_time=datetime.utcnow(),
+        )

--- a/tests/test_execution_tracker.py
+++ b/tests/test_execution_tracker.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.storage.relational_db_adapter import RelationalDBAdapter, Execution
+from app.storage.execution_tracker import ExecutionTracker
+
+
+def test_execution_tracker_flow():
+    """Valida ciclo completo do tracker."""
+    db = RelationalDBAdapter(db_url="sqlite:///:memory:")
+    tracker = ExecutionTracker(db, "tarefa", "Classe")
+
+    tracker.start()
+    tracker.update(progress=50.0)
+    tracker.finish()
+
+    session = db._Session()
+    row = session.query(Execution).first()
+    session.close()
+
+    assert row.task_name == "tarefa"
+    assert row.class_name == "Classe"
+    assert row.progress == 50.0
+    assert row.status == "success"
+    assert row.end_time is not None


### PR DESCRIPTION
## Summary
- create new execution tracking table and CRUD functions
- implement `ExecutionTracker` helper class
- log executions in structured data ingestor
- add tests for execution CRUD, tracker and ingestion updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68700226ada4832c9e945069c0af211b