### PR TITLE
Add new fields and contract object

### DIFF
--- a/app/models/contrato.py
+++ b/app/models/contrato.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+"""Objeto de domínio para representar e manipular contratos.
+
+Este módulo define a classe :class:`Contrato`, que corresponde a um registro da
+tabela ``contracts`` do banco relacional. A ideia é facilitar a manipulação de
+dados do contrato em memória, bem como fornecer utilidades para geração de
+relatórios em texto.
+"""
+
+from __future__ import annotations
+
+# Utilizamos dataclasses para simplificar a definição do objeto de domínio
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, date
+import json
+from typing import Any
+
+# Importação absoluta do ORM de contratos para evitar problemas de path
+from app.storage.relational_db_adapter import Contract
+
+
+@dataclass
+class Contrato:
+    """Representa um contrato carregado do banco relacional."""
+
+    # ------------------------------------------------------------------
+    # Campos que mapeiam diretamente as colunas da tabela ``contracts``
+    # ------------------------------------------------------------------
+
+    id: int | None
+    name: str
+    path: str
+    ingestion_date: datetime | None = None
+    last_processed: datetime | None = None
+    contrato: str | None = None
+    inicioPrazo: date | None = None
+    fimPrazo: date | None = None
+    empresa: str | None = None
+    icj: str | None = None
+    valorContratoOriginal: float | None = None
+    moeda: str | None = None
+    taxaCambio: float | None = None
+    gerenteContrato: str | None = None
+    nomeGerenteContrato: str | None = None
+    lotacaoGerenteContrato: str | None = None
+    areaContrato: str | None = None
+    modalidade: str | None = None
+    textoModalidade: str | None = None
+    reajuste: str | None = None
+    fornecedor: str | None = None
+    nomeFornecedor: str | None = None
+    tipoContrato: str | None = None
+    objetoContrato: str | None = None
+
+    # Linhas de serviço armazenadas em formato JSON
+    linhasServico: list[dict[str, Any]] | None = field(default=None)
+
+    # Vetor de embedding gerado pelo modelo e o texto completo do contrato
+    vetor_embedding: list[float] | None = field(default=None)
+    texto_completo: str | None = None
+
+    # ------------------------------------------------------------------
+    # Métodos auxiliares de construção e conversão
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_orm(cls, row: Contract) -> "Contrato":
+        """Cria instância a partir de um registro ORM."""
+
+        # Decodifica o JSON armazenado nas colunas ``linhasServico`` e
+        # ``vetor_embedding`` caso existam. Isso facilita o uso em código
+        # Python, evitando que cada chamada precise fazer ``json.loads``.
+        linhas = (
+            json.loads(row.linhasServico)
+            if getattr(row, "linhasServico", None)
+            else None
+        )
+        vetor = (
+            json.loads(row.vetor_embedding)
+            if getattr(row, "vetor_embedding", None)
+            else None
+        )
+        return cls(
+            id=row.id,
+            name=row.name,
+            path=row.path,
+            ingestion_date=row.ingestion_date,
+            last_processed=row.last_processed,
+            contrato=row.contrato,
+            inicioPrazo=row.inicioPrazo,
+            fimPrazo=row.fimPrazo,
+            empresa=row.empresa,
+            icj=row.icj,
+            valorContratoOriginal=float(row.valorContratoOriginal)
+            if row.valorContratoOriginal is not None
+            else None,
+            moeda=row.moeda,
+            taxaCambio=row.taxaCambio,
+            gerenteContrato=row.gerenteContrato,
+            nomeGerenteContrato=row.nomeGerenteContrato,
+            lotacaoGerenteContrato=row.lotacaoGerenteContrato,
+            areaContrato=row.areaContrato,
+            modalidade=row.modalidade,
+            textoModalidade=row.textoModalidade,
+            reajuste=row.reajuste,
+            fornecedor=row.fornecedor,
+            nomeFornecedor=row.nomeFornecedor,
+            tipoContrato=row.tipoContrato,
+            objetoContrato=row.objetoContrato,
+            linhasServico=linhas,
+            vetor_embedding=vetor,
+            texto_completo=row.texto_completo,
+        )
+
+    def to_dict(self) -> dict:
+        """Converte o contrato para ``dict`` padrão do Python.
+
+        Essa função facilita a serialização do objeto, seja para testes
+        ou para construção de relatórios em texto.
+        """
+        data = asdict(self)
+        return data
+
+    # Utilizamos __str__ para gerar representação legível
+    def __str__(self) -> str:  # pragma: no cover - delega para relatorio
+        return self.relatorio()
+
+    # ------------------------------------------------------------------
+    # Geração de relatório em formato de texto
+    # ------------------------------------------------------------------
+    def relatorio(self) -> str:
+        """Retorna relatório formatado com os dados do contrato.
+
+        Cada campo é apresentado no formato ``nome: valor`` e as linhas de
+        serviço, quando presentes, são exibidas em formato de tabela simples.
+        """
+        linhas = []
+        for field_name, value in self.to_dict().items():
+            # Tratamento especial para as linhas de serviço, que formam uma
+            # pequena tabela textual. Cada item da lista representa uma linha
+            # contendo as colunas originais do JSON.
+            if field_name == "linhasServico":
+                linhas.append("linhasServico:")
+                if value:
+                    cabecalho = list(value[0].keys())
+                    linhas.append(" | ".join(cabecalho))
+                    linhas.append("-" * (len(" | ".join(cabecalho))))
+                    for item in value:
+                        linhas.append(
+                            " | ".join(str(item.get(h, "")) for h in cabecalho)
+                        )
+                else:
+                    linhas.append("<vazio>")
+                continue
+            # Demais campos apenas concatenam nome e valor
+            linhas.append(f"{field_name}: {value}")
+        return "\n".join(linhas)

--- a/app/storage/relational_db_adapter.py
+++ b/app/storage/relational_db_adapter.py
@@ -45,6 +45,8 @@ class Contract(Base):
     tipoContrato = Column(String, nullable=True)
     objetoContrato = Column(String, nullable=True)
     linhasServico = Column(String, nullable=True)
+    vetor_embedding = Column(String, nullable=True)
+    texto_completo = Column(String, nullable=True)
 
 
 # Modelo ORM representando as execuções de tarefas

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -177,6 +177,8 @@ def test_get_contract_by_contrato(monkeypatch):
                 tipoContrato=None,
                 objetoContrato=None,
                 linhasServico=None,
+                vetor_embedding=None,
+                texto_completo=None,
             )
 
         def get_contract_by_contrato(self, contrato):

--- a/tests/test_contrato.py
+++ b/tests/test_contrato.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.storage.relational_db_adapter import RelationalDBAdapter, Contract
+from app.models.contrato import Contrato
+
+
+# Verifica criação do objeto a partir do ORM
+def test_contrato_from_orm_and_report():
+    db = RelationalDBAdapter(db_url="sqlite:///:memory:")
+    dados = {
+        "contrato": "C1",
+        "linhasServico": json.dumps([
+            {"Item": "1", "Desc": "X", "Num": "10", "Outra": "Y"}
+        ]),
+        "vetor_embedding": json.dumps([0.1, 0.2]),
+        "texto_completo": "Texto exemplo",
+    }
+    db.add_contract_structured(**dados)
+    session = db._Session()
+    row = session.query(Contract).first()
+    session.close()
+
+    contrato = Contrato.from_orm(row)
+    assert contrato.contrato == "C1"
+    assert contrato.vetor_embedding == [0.1, 0.2]
+    assert contrato.texto_completo == "Texto exemplo"
+    report = contrato.relatorio()
+    assert "contrato: C1" in report
+    assert "Item" in report
+

--- a/tests/test_relational_db.py
+++ b/tests/test_relational_db.py
@@ -50,6 +50,8 @@ def test_contract_model_attributes():
     assert c.tipoContrato is None
     assert c.objetoContrato is None
     assert c.linhasServico is None
+    assert c.vetor_embedding is None
+    assert c.texto_completo is None
 
 
 # Testa inserção de contrato no banco
@@ -86,6 +88,8 @@ def test_add_contract_inserts_into_db():
     assert row.tipoContrato is None
     assert row.objetoContrato is None
     assert row.linhasServico is None
+    assert row.vetor_embedding is None
+    assert row.texto_completo is None
 
 
 # Checa atualização da data de processamento


### PR DESCRIPTION
## Summary
- allow storing embedding vectors and full text for structured contracts
- implement a domain object `Contrato`
- provide report method and helper constructor
- cover new behaviour in unit tests
- move `Contrato` to models package

## Testing
- `env -u OPENAI_API_KEY pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68706b0156b8832c86236229881d5c2e