### PR TITLE
Add VPN-aware OpenAI integration

### DIFF
--- a/app/chat/chatbot.py
+++ b/app/chat/chatbot.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import List, Tuple
 
-from langchain.chat_models import ChatOpenAI
 from langchain.chains import RetrievalQA
+from app.integrations.openai_provider import get_chat_model
 
 from app.storage.vector_store_adapter import VectorStoreAdapter
 
@@ -16,7 +16,8 @@ class ContractChatbot:
     def __init__(self, vector_store: VectorStoreAdapter, model: str = "gpt-3.5-turbo") -> None:
         # Guarda a referência ao repositório vetorial
         self._vector_store = vector_store
-        self._llm = ChatOpenAI(model=model)
+        # Obtém o modelo adequado ao ambiente (interno ou público)
+        self._llm = get_chat_model(model=model)
         # Cria cadeia de consulta com base no Chroma
         self._chain = RetrievalQA.from_chain_type(
             llm=self._llm,

--- a/app/integrations/openai_provider.py
+++ b/app/integrations/openai_provider.py
@@ -1,0 +1,94 @@
+import os
+
+# Tenta importar dependências específicas da Petrobras para uso interno.
+# Em caso de falha, os objetos ficam como None e o código usa a API pública.
+try:  # pragma: no cover - pode não existir fora da VPN
+    from langchain_openai import AzureChatOpenAI, AzureOpenAIEmbeddings
+    from httpx import Client
+    from configparser import ConfigParser, ExtendedInterpolation
+except Exception:  # pragma: no cover - fora do ambiente interno
+    AzureChatOpenAI = None
+    AzureOpenAIEmbeddings = None
+    Client = None
+    ConfigParser = None
+    ExtendedInterpolation = None
+
+# Importa classes padrão do LangChain para acesso público.
+from langchain.chat_models import ChatOpenAI
+from langchain.embeddings import OpenAIEmbeddings
+
+# Constantes com parâmetros usados no ambiente corporativo
+_OPENAI_API_VERSION = "2024-03-01-preview"
+_OPENAI_BASE_URL = (
+    "https://apit.petrobras.com.br/ia/openai/v1/openai-azure/openai/deployments"
+)
+_CERT_PATH = "petrobras-ca-root.pem"
+_CONFIG_FILE = "config-v1.x.ini"
+
+
+def _load_internal_key() -> str | None:
+    """Lê a chave de API do arquivo de configuração interno."""
+    if ConfigParser is None:  # Dependência ausente
+        return None
+    cfg = ConfigParser(interpolation=ExtendedInterpolation())
+    try:
+        cfg.read(_CONFIG_FILE, "UTF-8")
+        return cfg.get("OPENAI", "OPENAI_API_KEY")
+    except Exception:  # pragma: no cover - arquivo opcional
+        return None
+
+
+def _create_azure_chat(model: str):
+    """Instancia o cliente AzureChatOpenAI quando possível."""
+    if AzureChatOpenAI is None:
+        return None
+    key = _load_internal_key()
+    if not key:
+        return None
+    return AzureChatOpenAI(
+        model=model,
+        openai_api_version=_OPENAI_API_VERSION,
+        openai_api_key=key,
+        base_url=f"{_OPENAI_BASE_URL}/{model}",
+        http_client=Client(verify=_CERT_PATH),
+    )
+
+
+def _create_azure_embeddings(model: str):
+    """Instancia AzureOpenAIEmbeddings quando disponível."""
+    if AzureOpenAIEmbeddings is None:
+        return None
+    key = _load_internal_key()
+    if not key:
+        return None
+    return AzureOpenAIEmbeddings(
+        model=model,
+        openai_api_version=_OPENAI_API_VERSION,
+        openai_api_key=key,
+        base_url=f"{_OPENAI_BASE_URL}/{model}",
+        http_client=Client(verify=_CERT_PATH),
+    )
+
+
+# Indica se devemos usar os serviços internos; controlado por variável de ambiente
+def _use_internal_services() -> bool:
+    return os.getenv("VPN_MODE") == "1"
+
+
+def get_chat_model(model: str = "gpt-3.5-turbo"):
+    """Devolve o modelo de chat apropriado ao ambiente."""
+    if _use_internal_services():
+        chat = _create_azure_chat(model)
+        if chat is not None:
+            return chat
+    # Fallback para API pública
+    return ChatOpenAI(model=model)
+
+
+def get_embeddings(model: str = "text-embedding-ada-002"):
+    """Retorna objeto de embeddings adequado ao ambiente."""
+    if _use_internal_services():
+        emb = _create_azure_embeddings(model)
+        if emb is not None:
+            return emb
+    return OpenAIEmbeddings(model=model)

--- a/app/storage/vector_store_adapter.py
+++ b/app/storage/vector_store_adapter.py
@@ -1,5 +1,6 @@
 from langchain.embeddings import OpenAIEmbeddings
 from langchain.vectorstores import Chroma
+from app.integrations.openai_provider import get_embeddings
 from pathlib import Path
 import shutil
 
@@ -13,7 +14,8 @@ class VectorStoreAdapter:
     def __init__(self, persist_directory: str = "chroma_db") -> None:
         # Diretório onde o Chroma irá persistir os dados
         self._persist_directory = persist_directory
-        self._embedding = OpenAIEmbeddings()
+        # Instancia embeddings adequados ao ambiente (interno ou público)
+        self._embedding = get_embeddings()
         self._store = Chroma(
             persist_directory=persist_directory, embedding_function=self._embedding
         )

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -18,6 +18,8 @@ sys.modules.setdefault("langchain", langchain_stub)
 sys.modules.setdefault("langchain.embeddings", langchain_stub.embeddings)
 sys.modules.setdefault("langchain.vectorstores", langchain_stub.vectorstores)
 
+import app.integrations.openai_provider as openai_provider
+
 from app.storage import vector_store_adapter
 
 
@@ -48,7 +50,7 @@ def test_add_and_persist(monkeypatch):
         return dummy_store
 
     monkeypatch.setattr(vector_store_adapter, "Chroma", dummy_chroma)
-    monkeypatch.setattr(vector_store_adapter, "OpenAIEmbeddings", lambda: DummyEmbeddings())
+    monkeypatch.setattr(openai_provider, "get_embeddings", lambda: DummyEmbeddings())
 
     adapter = vector_store_adapter.VectorStoreAdapter(persist_directory="test_db")
 
@@ -72,7 +74,7 @@ def test_clear_reinitializes_store(monkeypatch, tmp_path):
         return second_store
 
     monkeypatch.setattr(vector_store_adapter, "Chroma", first_chroma)
-    monkeypatch.setattr(vector_store_adapter, "OpenAIEmbeddings", lambda: DummyEmbeddings())
+    monkeypatch.setattr(openai_provider, "get_embeddings", lambda: DummyEmbeddings())
     adapter = vector_store_adapter.VectorStoreAdapter(persist_directory=str(tmp_path))
     assert adapter._store is first_store
 


### PR DESCRIPTION
## Summary
- introduce `openai_provider` that switches LangChain models when `VPN_MODE=1`
- connect `ContractChatbot` and `VectorStoreAdapter` to this provider
- adjust vector store tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6871756ec454832ca68315fbb9896d5a