### PR TITLE
Implement ExhaustiveProcessor

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -9,6 +9,7 @@ from app.storage.relational_db_adapter import (
     Prompt,
 )
 from app.chat.chatbot import ContractChatbot
+from app.processing.execution import ExhaustiveProcessor
 
 router = APIRouter()
 
@@ -211,3 +212,15 @@ def delete_prompt(prompt_id: int) -> dict:
     """Remove um prompt do banco."""
     _relational_db.delete_prompt(prompt_id)
     return {"status": "ok"}
+
+
+# ------------------------------------------------------------
+# Endpoint para execução exaustiva de prompts
+
+@router.post("/execute")
+async def execute_prompts(prompt: str | None = Body(None, embed=True)) -> dict:
+    """Dispara processamento dos contratos com prompts."""
+    processor = ExhaustiveProcessor(_vector_store, _relational_db)
+    ids = await processor.run(prompt=prompt)
+    return {"ids": ids}
+

--- a/app/processing/execution.py
+++ b/app/processing/execution.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+
+from app.integrations.openai_provider import get_chat_model
+from app.storage.vector_store_adapter import VectorStoreAdapter
+from app.storage.relational_db_adapter import (
+    RelationalDBAdapter,
+    Contract,
+)
+from app.models.contrato import Contrato
+
+
+# Classe responsável por executar prompts em todos os contratos
+class ExhaustiveProcessor:
+    """Executa prompts cadastrados ou ad-hoc sobre todos os contratos."""
+
+    def __init__(
+        self,
+        vector_store: VectorStoreAdapter,
+        relational_db: RelationalDBAdapter,
+        *,
+        model: str = "gpt-3.5-turbo",
+        max_concurrent: int = 3,
+    ) -> None:
+        # Armazena dependências para acesso posterior
+        self._vector_store = vector_store
+        self._db = relational_db
+        self._llm = get_chat_model(model=model)
+        self._max_concurrent = max_concurrent
+
+    async def run(self, prompt: str | None = None) -> list[int]:
+        """Dispara a execução e retorna ids das execuções criadas."""
+        # Recupera todos os contratos disponíveis
+        session = self._db._Session()
+        contracts = session.query(Contract).order_by(Contract.id).all()
+        session.close()
+
+        # Determina os prompts a executar: único ad-hoc ou todos cadastrados
+        if prompt is not None:
+            prompts: list[tuple[int | None, str]] = [(None, prompt)]
+        else:
+            prompts = [(p.id, p.texto) for p in self._db.list_prompts()]
+
+        exec_ids: list[int] = []
+        for pid, text in prompts:
+            tipo = "adhoc" if pid is None else "registrado"
+            exec_id = self._db.create_execution(
+                "prompt_execution",
+                self.__class__.__name__,
+                tipo=tipo,
+                prompt_id=pid,
+                prompt_text=text,
+            )
+            exec_ids.append(exec_id)
+            await self._run_single(exec_id, text, contracts)
+        return exec_ids
+
+    async def _run_single(
+        self, exec_id: int, prompt_text: str, contracts: list[Contract]
+    ) -> None:
+        """Executa um prompt sobre todos os contratos."""
+        total = len(contracts)
+        processed = 0
+        lock = asyncio.Lock()
+        sem = asyncio.Semaphore(self._max_concurrent)
+
+        async def handle(contract: Contract) -> None:
+            nonlocal processed
+            async with sem:
+                # Monta o texto completo a ser enviado ao modelo
+                contrato = Contrato.from_orm(contract)
+                texto = f"{prompt_text}\n\n{contrato.relatorio()}"
+                # Chamada assíncrona ao modelo de linguagem
+                if hasattr(self._llm, "ainvoke"):
+                    resposta = await self._llm.ainvoke(texto)
+                else:
+                    resposta = await asyncio.to_thread(self._llm.predict, texto)
+                simples = resposta.strip().split("\n", 1)[0] if resposta else None
+                self._db.add_execution_result(
+                    exec_id,
+                    contract.id,
+                    resposta_completa=resposta,
+                    resposta_simples=simples,
+                )
+                # Atualiza progresso de forma sincronizada
+                async with lock:
+                    processed += 1
+                    progress = processed / total * 100
+                    self._db.update_execution(exec_id, progress=progress)
+
+        # Dispara processamento paralelo leve
+        await asyncio.gather(*(handle(c) for c in contracts))
+        # Finaliza registro da execução
+        self._db.update_execution(
+            exec_id,
+            status="success",
+            end_time=datetime.utcnow(),
+            progress=100.0,
+        )

--- a/tests/test_exhaustive_processor.py
+++ b/tests/test_exhaustive_processor.py
@@ -1,0 +1,75 @@
+import asyncio
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.storage.relational_db_adapter import (
+    RelationalDBAdapter,
+    Contract,
+    Execution,
+    ExecutionResult,
+)
+import app.processing.execution as execution_mod
+from app.processing.execution import ExhaustiveProcessor
+
+
+class DummyLLM:
+    def __init__(self):
+        self.prompts = []
+
+    def predict(self, text: str) -> str:
+        self.prompts.append(text)
+        return "resp"
+
+
+def test_run_adhoc(monkeypatch):
+    db = RelationalDBAdapter(db_url="sqlite:///:memory:")
+    db.add_contract_structured(contrato="C1")
+    db.add_contract_structured(contrato="C2")
+
+    llm = DummyLLM()
+    monkeypatch.setattr(execution_mod, "get_chat_model", lambda model="x": llm)
+
+    proc = ExhaustiveProcessor(object(), db)
+    ids = asyncio.run(proc.run(prompt="Oi?"))
+
+    assert ids == [1]
+    session = db._Session()
+    exec_row = session.query(Execution).first()
+    results = session.query(ExecutionResult).all()
+    session.close()
+
+    assert exec_row.tipo == "adhoc"
+    assert exec_row.prompt_text == "Oi?"
+    assert exec_row.progress == 100.0
+    assert len(results) == 2
+    assert all(r.execution_id == exec_row.id for r in results)
+    assert len(llm.prompts) == 2
+
+
+def test_run_registered(monkeypatch):
+    db = RelationalDBAdapter(db_url="sqlite:///:memory:")
+    db.add_contract_structured(contrato="C1")
+    p1 = db.add_prompt(nome="p1", texto="T1")
+    p2 = db.add_prompt(nome="p2", texto="T2")
+
+    llm = DummyLLM()
+    monkeypatch.setattr(execution_mod, "get_chat_model", lambda model="x": llm)
+
+    proc = ExhaustiveProcessor(object(), db)
+    ids = asyncio.run(proc.run())
+
+    assert len(ids) == 2
+    session = db._Session()
+    execs = session.query(Execution).order_by(Execution.id).all()
+    results = session.query(ExecutionResult).all()
+    session.close()
+
+    assert {e.prompt_id for e in execs} == {p1, p2}
+    assert all(e.tipo == "registrado" for e in execs)
+    assert len(results) == 2
+    assert len(llm.prompts) == 2
+


### PR DESCRIPTION
## Summary
- add ExhaustiveProcessor class able to run prompts over all contracts
- expose processor via new `/execute` API endpoint
- cover new functionality with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68718a8bca80832c8f9be987aa294e6d