### PR TITLE
Add Prompts management tab

### DIFF
--- a/app/ui/chat.py
+++ b/app/ui/chat.py
@@ -1,48 +1,56 @@
 # Interface de usuário baseada em Streamlit
 import streamlit as st
-
 import httpx
 
 from app.config import API_BASE_URL
-
+from .prompts import render as render_prompts_tab
 
 # Endpoint da API de chat
 _CHAT_ENDPOINT = f"{API_BASE_URL.rstrip('/')}/chat"
 
 
-# Função principal responsável por exibir a página
-def main() -> None:
-    """Renderiza a interface principal de chat."""
-    st.set_page_config(page_title="Novo VCC - Chat", layout="centered")
+def _chat_tab() -> None:
+    """Renderiza os controles da aba de chat."""
 
-    # Barra lateral com navegação
-    with st.sidebar:
-        st.markdown("# Novo VCC")
-        st.markdown("[Chat](#)")
-        st.markdown("[Config](#)")
+    st.markdown("## Chat sobre contratos")
 
-    st.title("Chat sobre contratos")  # cabeçalho principal
-
-    question = st.text_input("Faça sua pergunta sobre os contratos:")  # entrada do usuário
-    if question:
-        # Envia a pergunta para a API
+    pergunta = st.text_input("Faça sua pergunta sobre os contratos:")
+    if pergunta:
         try:
-            response = httpx.post(_CHAT_ENDPOINT, json={"question": question}, timeout=30.0)
-            response.raise_for_status()
-            data = response.json()
-            answer = data.get("answer", "")
-            sources = data.get("sources", [])
-        except Exception as exc:
+            resp = httpx.post(_CHAT_ENDPOINT, json={"question": pergunta}, timeout=30.0)
+            resp.raise_for_status()
+            dados = resp.json()
+            resposta = dados.get("answer", "")
+            fontes = dados.get("sources", [])
+        except Exception as exc:  # Trata falhas ao chamar a API
             st.error(f"Erro ao consultar a API: {exc}")
             return
 
-        st.markdown("## Resposta")
-        st.write(answer)
+        st.markdown("### Resposta")
+        st.write(resposta)
 
-        if sources:
-            st.markdown("## Contratos relevantes")
-            for src in sources:  # lista de arquivos retornados
+        if fontes:
+            st.markdown("### Contratos relevantes")
+            for src in fontes:
                 st.write(src)
+
+
+def main() -> None:
+    """Renderiza a aplicação com abas Chat e Prompts."""
+
+    st.set_page_config(page_title="Novo VCC", layout="centered")
+
+    with st.sidebar:
+        st.markdown("# Novo VCC")
+        st.markdown("Utilize as abas acima")
+
+    aba_chat, aba_prompts = st.tabs(["Chat", "Prompts"])
+
+    with aba_chat:
+        _chat_tab()
+
+    with aba_prompts:
+        render_prompts_tab()
 
 
 # Inicia a aplicação quando executado diretamente

--- a/app/ui/prompts.py
+++ b/app/ui/prompts.py
@@ -1,0 +1,96 @@
+# Página de gerenciamento de prompts via Streamlit
+import streamlit as st
+import httpx
+
+from app.config import API_BASE_URL
+
+# Endpoints da API para CRUD de prompts
+_PROMPTS_ENDPOINT = f"{API_BASE_URL.rstrip('/')}/prompts"
+
+
+def render() -> None:
+    """Exibe a aba de prompts com operações de CRUD."""
+
+    # Tenta carregar lista de prompts existentes
+    try:
+        resp = httpx.get(_PROMPTS_ENDPOINT, timeout=10.0)
+        resp.raise_for_status()
+        prompts = resp.json().get("prompts", [])
+    except Exception as exc:  # Caso ocorra erro na requisição
+        st.error(f"Erro ao carregar prompts: {exc}")
+        prompts = []
+
+    st.markdown("## Prompts cadastrados")
+
+    # Tabela simples com os dados retornados
+    if prompts:
+        st.table(prompts)
+    else:
+        st.info("Nenhum prompt encontrado.")
+
+    st.markdown("---")
+    st.markdown("### Incluir novo prompt")
+    with st.form("add_prompt"):
+        nome = st.text_input("Nome")
+        texto = st.text_area("Texto")
+        periodicidade = st.text_input("Periodicidade (opcional)")
+        submitted = st.form_submit_button("Cadastrar")
+        if submitted:
+            try:
+                httpx.post(
+                    _PROMPTS_ENDPOINT,
+                    json={
+                        "nome": nome,
+                        "texto": texto,
+                        "periodicidade": periodicidade or None,
+                    },
+                    timeout=10.0,
+                ).raise_for_status()
+                st.success("Prompt cadastrado com sucesso!")
+                st.experimental_rerun()
+            except Exception as exc:
+                st.error(f"Erro ao cadastrar prompt: {exc}")
+
+    st.markdown("---")
+    st.markdown("### Alterar ou excluir")
+
+    if prompts:
+        # Seleção do prompt existente
+        options = {f"{p['id']} - {p['nome']}": p for p in prompts}
+        chave = st.selectbox("Escolha o prompt", list(options.keys()))
+        selected = options[chave]
+        with st.form("edit_prompt"):
+            nome_e = st.text_input("Nome", value=selected["nome"])
+            texto_e = st.text_area("Texto", value=selected["texto"])
+            periodicidade_e = st.text_input(
+                "Periodicidade (opcional)", value=selected["periodicidade"] or ""
+            )
+            col1, col2 = st.columns(2)
+            atualizar = col1.form_submit_button("Atualizar")
+            excluir = col2.form_submit_button("Excluir")
+            if atualizar:
+                try:
+                    httpx.put(
+                        f"{_PROMPTS_ENDPOINT}/{selected['id']}",
+                        json={
+                            "nome": nome_e,
+                            "texto": texto_e,
+                            "periodicidade": periodicidade_e or None,
+                        },
+                        timeout=10.0,
+                    ).raise_for_status()
+                    st.success("Prompt atualizado!")
+                    st.experimental_rerun()
+                except Exception as exc:
+                    st.error(f"Erro ao atualizar: {exc}")
+            if excluir:
+                try:
+                    httpx.delete(
+                        f"{_PROMPTS_ENDPOINT}/{selected['id']}", timeout=10.0
+                    ).raise_for_status()
+                    st.success("Prompt removido!")
+                    st.experimental_rerun()
+                except Exception as exc:
+                    st.error(f"Erro ao excluir: {exc}")
+    else:
+        st.info("Nenhum prompt para editar ou excluir.")


### PR DESCRIPTION
## Summary
- create Prompts tab to manage prompt CRUD via API
- integrate new tab with Chat interface

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_687199246ca8832c8ba75af266aee36a