### PR TITLE
Atualiza openai_provider e README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ poetry run python main.py
 
 Se desejar utilizar os serviços internos de IA da Petrobras, coloque os arquivos
 `petrobras-ca-root.pem` e `config-v1.x.ini` no diretório `app/config`. Caso
-precise apontar para outro local, defina as variáveis `VPN_CERT_PATH` e
-`VPN_CONFIG_FILE` com os caminhos completos de cada arquivo.
+esses arquivos estejam presentes, o `openai_provider` fará a leitura automática
+sem precisar definir variáveis de ambiente adicionais.
 
 Para que o módulo `openai_provider` utilize essas configurações, exporte a
 variável `VPN_MODE=1` antes de executar a aplicação. Quando não definida, a

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -66,6 +66,8 @@ def test_uses_azure_when_available(monkeypatch):
     monkeypatch.setattr(openai_provider, "AzureOpenAIEmbeddings", DummyAzureEmb)
     monkeypatch.setattr(openai_provider, "Client", DummyClient)
     monkeypatch.setattr(openai_provider, "_load_internal_key", lambda: "k")
+    # Garante que o caminho do certificado exista para o teste
+    monkeypatch.setattr(openai_provider, "_CERT_PATH", Path(__file__))
 
     chat = openai_provider.get_chat_model()
     emb = openai_provider.get_embeddings()
@@ -81,6 +83,7 @@ def test_fallback_without_key(monkeypatch):
     monkeypatch.setattr(openai_provider, "AzureOpenAIEmbeddings", DummyAzureEmb)
     monkeypatch.setattr(openai_provider, "Client", DummyClient)
     monkeypatch.setattr(openai_provider, "_load_internal_key", lambda: None)
+    monkeypatch.setattr(openai_provider, "_CERT_PATH", Path(__file__))
 
     chat = openai_provider.get_chat_model()
     emb = openai_provider.get_embeddings()
@@ -96,6 +99,7 @@ def test_fallback_when_vpn_disabled(monkeypatch):
     monkeypatch.setattr(openai_provider, "AzureOpenAIEmbeddings", DummyAzureEmb)
     monkeypatch.setattr(openai_provider, "Client", DummyClient)
     monkeypatch.setattr(openai_provider, "_load_internal_key", lambda: "k")
+    monkeypatch.setattr(openai_provider, "_CERT_PATH", Path(__file__))
 
     chat = openai_provider.get_chat_model()
     emb = openai_provider.get_embeddings()


### PR DESCRIPTION
## Summary
- ajusta busca de arquivos de config e certificado
- simplifica blocos de importação
- adapta testes ao novo comportamento
- documenta leitura automática em README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a28501ff8832c9fa62f5e9a34ce1d