### PR TITLE
Adiciona avisos de log quando config ausente

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ poetry run python main.py
 Se desejar utilizar os serviços internos de IA da Petrobras, coloque os arquivos
 `petrobras-ca-root.pem` e `config-v1.x.ini` no diretório `app/config`. Caso
 esses arquivos estejam presentes, o `openai_provider` fará a leitura automática
-sem precisar definir variáveis de ambiente adicionais.
+sem precisar definir variáveis de ambiente adicionais. Quando algum deles
+estiver ausente, mensagens de aviso serão registradas no log.
 
 Para que o módulo `openai_provider` utilize essas configurações, exporte a
 variável `VPN_MODE=1` antes de executar a aplicação. Quando não definida, a

--- a/app/integrations/openai_provider.py
+++ b/app/integrations/openai_provider.py
@@ -1,6 +1,10 @@
 import os
+import logging
 from pathlib import Path
 from configparser import ConfigParser, ExtendedInterpolation
+
+# Cria objeto de log com o nome deste módulo
+logger = logging.getLogger(__name__)
 
 # Tenta importar dependências utilizadas internamente.
 # Todas são bibliotecas públicas e independem de acesso via VPN.
@@ -37,6 +41,8 @@ def _load_internal_key() -> str | None:
     """Lê a chave de API do arquivo de configuração interno."""
     # Caso o arquivo não exista, simplesmente retornamos ``None``
     if not _CONFIG_FILE.exists():
+        # Emite aviso informando que o arquivo esperado nao foi encontrado
+        logger.warning("Arquivo de configuração %s não encontrado", _CONFIG_FILE)
         return None
 
     cfg = ConfigParser(interpolation=ExtendedInterpolation())
@@ -52,7 +58,8 @@ def _create_azure_chat(model: str):
     if AzureChatOpenAI is None:
         return None
     if not _CERT_PATH.exists():
-        # Certificado ausente: não é possível configurar o cliente interno
+        # Certificado ausente: registra aviso e interrompe a configuração interna
+        logger.warning("Certificado %s não encontrado", _CERT_PATH)
         return None
     key = _load_internal_key()
     if not key:
@@ -71,7 +78,8 @@ def _create_azure_embeddings(model: str):
     if AzureOpenAIEmbeddings is None:
         return None
     if not _CERT_PATH.exists():
-        # Certificado ausente: devolve ``None`` para forçar o fallback
+        # Certificado ausente: devolve ``None`` e registra aviso para forçar o fallback
+        logger.warning("Certificado %s não encontrado", _CERT_PATH)
         return None
     key = _load_internal_key()
     if not key:


### PR DESCRIPTION
## Summary
- adiciona logger em `openai_provider`
- gera warnings quando cert ou config não existem
- documenta os avisos no README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a29e5e2b8832c8f387bbd4876bc05