### PR TITLE
Atualiza ChromaDB e prioriza Nexus

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Variáveis de ambiente para execução local
+# Insira sua chave da OpenAI aqui
+OPENAI_API_KEY=insira-sua-chave
+
+# Desativa telemetria anônima do ChromaDB
+ANONYMIZED_TELEMETRY=False

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ pip install poetry
 poetry install
 
 # Criar .env com chave da OpenAI (exemplo no .env.example)
+# Para evitar chamadas externas do ChromaDB,
+# defina também `ANONYMIZED_TELEMETRY=False` no arquivo .env
 
 # Executar a API FastAPI
 poetry run python api_main.py

--- a/app/storage/vector_store_adapter.py
+++ b/app/storage/vector_store_adapter.py
@@ -1,4 +1,6 @@
-from langchain.vectorstores import Chroma
+# A classe Chroma mudou de local. Agora ela é fornecida
+# pelo pacote `langchain-chroma`.
+from langchain_chroma import Chroma
 from app.integrations.openai_provider import get_embeddings
 from pathlib import Path
 import shutil
@@ -7,21 +9,24 @@ import shutil
 # Envolve o Chroma para facilitar o uso pela aplicação
 # Classe adaptadora para interagir com o Chroma usando embeddings OpenAI
 class VectorStoreAdapter:
-    """Wrapper around Chroma vector store using OpenAI embeddings."""
+    """Wrapper em Português para o vector store Chroma usando embeddings OpenAI."""
 
     # Cria o objeto definindo diretório de persistência
     def __init__(self, persist_directory: str = "chroma_db") -> None:
-        # Diretório onde o Chroma irá persistir os dados
+        """Inicializa o adaptador com o caminho de persistência."""
+        # Diretório onde o Chroma irá manter seus arquivos
         self._persist_directory = persist_directory
-        # Instancia embeddings adequados ao ambiente (interno ou público)
+        # Embeddings específicos de acordo com o modo de execução
         self._embedding = get_embeddings()
+        # Cria ou carrega o banco vetorial
         self._store = Chroma(
-            persist_directory=persist_directory, embedding_function=self._embedding
+            persist_directory=persist_directory,
+            embedding_function=self._embedding,
         )
 
     # Insere um documento de texto no vetor
     def add_document(self, text: str, metadata: dict | None = None) -> None:
-        """Adiciona um texto com metadados ao vetor."""
+        """Adiciona um texto ao vetor, registrando metadados opcionais."""
         self._store.add_texts([text], metadatas=[metadata or {}])
 
     # Persiste as alterações realizadas

--- a/poetry.lock
+++ b/poetry.lock
@@ -1320,6 +1320,26 @@ together = ["langchain-together"]
 xai = ["langchain-xai"]
 
 [[package]]
+name = "langchain-chroma"
+version = "0.2.4"
+description = "An integration package connecting Chroma and LangChain."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "langchain_chroma-0.2.4-py3-none-any.whl", hash = "sha256:8bd5316ab415ff7c6ac911d2069926a54777aa4a04f69239a422415c02d1feeb"},
+    {file = "langchain_chroma-0.2.4.tar.gz", hash = "sha256:d021ebf743969f6c2887b3878e829d1814d770e2bbf8e22df7d8cce15efed0d7"},
+]
+
+[package.dependencies]
+chromadb = ">=1.0.9"
+langchain-core = ">=0.3.60"
+numpy = [
+    {version = ">=1.26.0", markers = "python_version < \"3.13\""},
+    {version = ">=2.1.0", markers = "python_version >= \"3.13\""},
+]
+
+[[package]]
 name = "langchain-core"
 version = "0.3.68"
 description = "Building applications with LLMs through composability"
@@ -4288,4 +4308,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "3ee6f03abb8f31a3adbb211151994cf80c900be98dd64058749fcc8f562cc3db"
+content-hash = "7f2e17ad673686b626b8883d014d3baf10c409e454a0c7e899f03b8ddc9e2ec8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,12 +9,13 @@ authors = ["Seu Nome <seuemail@example.com>"]
 [[tool.poetry.source]]
 name = "nexus"
 url = "http://nexus.petrobras.com.br/nexus/repository/pypi-all/simple/"
-priority = "supplemental"
+priority = "primary"
 
 [tool.poetry.dependencies]
 python = "^3.11"
 langchain = "*"
 chromadb = "*"
+langchain-chroma = "*"
 openai = "*"
 langchain-openai = "*"
 streamlit = "*"


### PR DESCRIPTION
## Resumo
- substitui import do Chroma para usar `langchain-chroma`
- adiciona dependência `langchain-chroma`
- define `ANONYMIZED_TELEMETRY=False` em `.env.example`
- prioriza repositório Nexus
- documenta configuração no README

## Testes
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a8e90c200832c95d32a20d5f36906